### PR TITLE
chore(package.json): remove needless babel-eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,13 @@ module.exports = {
         "eslint:recommended",
         "plugin:react/recommended"
     ],
-    parser: 'babel-eslint',
+    parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+        ecmaFeatures: {
+            'jsx': true
+        },
+    },
     env: {
         es6: true,
         browser: true
@@ -11,10 +17,6 @@ module.exports = {
     plugins: [
         "react"
     ],
-    ecmaFeatures: {
-        jsx: true,
-        modules: true
-    },
     globals: {},
     rules: {
         'no-console': 0,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "devDependencies": {
     "babel-core": "^6.9.1",
-    "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.2",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.9.0",


### PR DESCRIPTION
Now, we don't have to use babel-eslint to test ES6 code!
