### PR TITLE
wercker: use suzuken/go-node box

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: golang
+box: suzuken/go-node:latest
 
 build:
   steps:


### PR DESCRIPTION
Currently, build is failed because of missing `npm`. So I created new box `suzuken/go-node` which includes latest Go and Node 6.x .
